### PR TITLE
Jelly: Show a Snackbar when removing an HistoryItem

### DIFF
--- a/app/src/main/java/org/lineageos/jelly/history/HistoryActivity.java
+++ b/app/src/main/java/org/lineageos/jelly/history/HistoryActivity.java
@@ -24,6 +24,7 @@ import android.database.Cursor;
 import android.os.AsyncTask;
 import android.os.Bundle;
 import android.os.Handler;
+import android.support.design.widget.Snackbar;
 import android.support.v7.app.AlertDialog;
 import android.support.v7.app.AppCompatActivity;
 import android.support.v7.widget.DefaultItemAnimator;
@@ -91,7 +92,14 @@ public class HistoryActivity extends AppCompatActivity {
 
         mAdapter.registerAdapterDataObserver(mAdapterDataObserver);
 
-        ItemTouchHelper helper = new ItemTouchHelper(new HistoryCallBack(this));
+        ItemTouchHelper helper = new ItemTouchHelper(new HistoryCallBack(this, values -> {
+            View rootView = findViewById(R.id.coordinator_layout);
+            Snackbar.make(rootView, R.string.history_snackbar_item_deleted, Snackbar.LENGTH_LONG)
+                    .setAction(R.string.history_snackbar_item_deleted_message, l -> {
+                        getContentResolver().insert(HistoryProvider.Columns.CONTENT_URI, values);
+                    })
+                    .show();
+        }));
         helper.attachToRecyclerView(list);
 
         int listTop = list.getTop();

--- a/app/src/main/java/org/lineageos/jelly/history/HistoryAdapter.java
+++ b/app/src/main/java/org/lineageos/jelly/history/HistoryAdapter.java
@@ -73,12 +73,11 @@ class HistoryAdapter extends RecyclerView.Adapter<HistoryHolder> {
         if (!mCursor.moveToPosition(position)) {
             return;
         }
-        long id = mCursor.getLong(mIdColumnIndex);
         long timestamp = mCursor.getLong(mTimestampColumnIndex);
         String summary = mHistoryDateFormat.format(new Date(timestamp));
         String title = mCursor.getString(mTitleColumnIndex);
         String url = mCursor.getString(mUrlColumnIndex);
-        holder.bind(mContext, id, title, url, summary, timestamp);
+        holder.bind(mContext, title, url, summary, timestamp);
     }
 
     @Override

--- a/app/src/main/java/org/lineageos/jelly/history/HistoryHolder.java
+++ b/app/src/main/java/org/lineageos/jelly/history/HistoryHolder.java
@@ -15,13 +15,13 @@
  */
 package org.lineageos.jelly.history;
 
-import android.content.ContentUris;
 import android.content.Context;
 import android.content.Intent;
 import android.graphics.drawable.ColorDrawable;
 import android.net.Uri;
 import android.support.v4.content.ContextCompat;
 import android.support.v7.widget.RecyclerView;
+import android.text.TextUtils;
 import android.view.View;
 import android.widget.LinearLayout;
 import android.widget.TextView;
@@ -43,24 +43,15 @@ class HistoryHolder extends RecyclerView.ViewHolder {
         mSummary = view.findViewById(R.id.row_history_summary);
     }
 
-    void bind(final Context context, final long id, String title, String url, String summary,
-              long timestamp) {
-        if (title == null || title.isEmpty()) {
-            title = url.split("/")[2];
-        }
-        mTitle.setText(title);
+    void bind(final Context context, String title, String url, String summary, long timestamp) {
+        final String historyTitle = TextUtils.isEmpty(title) ? url.split("/")[2] : title;
+        mTitle.setText(historyTitle);
         mSummary.setText(summary);
 
         mRootLayout.setOnClickListener(v -> {
             Intent intent = new Intent(context, MainActivity.class);
             intent.setData(Uri.parse(url));
             context.startActivity(intent);
-        });
-
-        mRootLayout.setOnLongClickListener(v -> {
-            Uri uri = ContentUris.withAppendedId(HistoryProvider.Columns.CONTENT_URI, id);
-            context.getContentResolver().delete(uri, null, null);
-            return true;
         });
 
         int background;

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -130,6 +130,10 @@
     <string name="history_delete_positive">Clear</string>
     <!-- History: delete history "working" dialog-->
     <string name="history_deleting_message">Clearing history\u2026</string>
+    <!-- History: entry deleted snackbar message -->
+    <string name="history_snackbar_item_deleted">Entry deleted</string>
+    <!-- History: entry deleted snackbar button message -->
+    <string name="history_snackbar_item_deleted_message">Undo</string>
 
     <!-- Favorite: title -->
     <string name="favorite_title">Favorites</string>


### PR DESCRIPTION
This allows users to re-add the entry if deleted accidentally.

Also remove the long-press-to-delete functionality for history items, as
it would be quite a bit of additional effort to implement the SnackBar
for it and multiple ways of doing the same thing seem redundant anyway.

Change-Id: I14bea962e67bf0e3a9af67ef4cd141cbf322e3dd
(cherry picked from commit 1efae6f80c1382ae135e33f2392d3cdc06b0a338)